### PR TITLE
Make it possible to update children of groups

### DIFF
--- a/inventoryctl.py
+++ b/inventoryctl.py
@@ -367,7 +367,7 @@ class InventoryCtl(object):
         group = groups[gname]
         parent = None
         if self.args.parent in groups:
-            parent = group[self.args.parent]
+            parent = groups[self.args.parent]
 
         if self.args.update:
             print('Update mode')
@@ -400,8 +400,9 @@ class InventoryCtl(object):
 
             # modify parent group
             if parent is not None:
-                sql = """UPDATE `childgroups` SET `parent_id` = %d WHERE `child_id` = %d;"""
-                affected_rows += self.__cursor.execute(sql % (group['id'], parent['id']))
+                sql = """INSERT INTO `childgroups` (`child_id`,`parent_id`) VALUES
+                              (%d,%d) ON DUPLICATE KEY UPDATE `child_id` = %d, `parent_id` = %d;"""
+                affected_rows += self.__cursor.execute(sql % (group['id'], parent['id'], group['id'], parent['id']))
 
             self.conn.commit()
 


### PR DESCRIPTION
When a group is updated and a parent is added the script should insert the mysql data and only if it exists it should get updated.

Additionally when searching for groups it needs to search in the groups array for the parent instead of the group which represents the group that gets updated in the command.

Maybe somebody is still using this portion of code. :)